### PR TITLE
Small fix for the output of the scrapping

### DIFF
--- a/src/main/java/com/polytech/webscraipper/services/DocumentService.java
+++ b/src/main/java/com/polytech/webscraipper/services/DocumentService.java
@@ -196,7 +196,7 @@ public class DocumentService {
 
         document.select("script, style, form, nav, aside, button, svg").remove();
         // TODO: think about the iframe
-        return document.text();
+        return document.toString();
     }
 
     public boolean isYoutubeVideo(String videoUrl) {


### PR DESCRIPTION
document.text sends only the text without the divs. toString sends everything. This is better because chatGpt can understand it better